### PR TITLE
fix package scripts, server join fallback logic, and reconnect timer leaks

### DIFF
--- a/bot-authme-first.js
+++ b/bot-authme-first.js
@@ -120,9 +120,10 @@ function createBot() {
     const lowerMessage = message.toLowerCase();
     
     // Server join success detection (for survival server)
-    if (serverJoined && lowerMessage.includes('survival') && 
+    if (!serverJoined && lowerMessage.includes('survival') && 
         (lowerMessage.includes('joined') || lowerMessage.includes('connected') || lowerMessage.includes('welcome'))) {
       console.log('🌍 Successfully joined survival server!');
+      serverJoined = true;
       console.log('📋 Step 3: Starting bot activities...');
       setTimeout(startBotActivities, 2000);
     }
@@ -164,6 +165,7 @@ function createBot() {
         }, config.serverCommands.delay);
       } else {
         // If no server command, just start activities
+        serverJoined = true;
         setTimeout(startBotActivities, 2000);
       }
     }
@@ -265,12 +267,12 @@ function joinSpecificServer() {
   
   bot.chat(config.serverCommands.joinServer);
   console.log(`📤 Sent server join command: ${config.serverCommands.joinServer}`);
-  serverJoined = true;
 
   // If no response indicating successful server join after 10 seconds, start activities anyway
   setTimeout(() => {
     if (authmeCompleted && !serverJoined) {
       console.log('⚠️ No server join confirmation, starting activities anyway...');
+      serverJoined = true;
       startBotActivities();
     }
   }, 10000);
@@ -310,6 +312,7 @@ function attemptAuthMeLogin() {
           joinSpecificServer();
         }, config.serverCommands.delay);
       } else {
+        serverJoined = true;
         startBotActivities();
       }
     }

--- a/bot-authme-first.js
+++ b/bot-authme-first.js
@@ -60,10 +60,37 @@ let loginAttempts = 0;
 let serverJoined = false;
 let authmeCompleted = false;
 const maxLoginAttempts = 3;
+let antiAfkInterval = null;
+let chatInterval = null;
+let reconnectTimeout = null;
+
+function scheduleReconnect() {
+  if (!config.features.autoReconnect.enabled) return;
+  if (reconnectTimeout) return;
+
+  console.log(`🔄 Reconnecting in ${config.features.autoReconnect.delay / 1000} seconds...`);
+  reconnectTimeout = setTimeout(() => {
+    reconnectTimeout = null;
+    createBot();
+  }, config.features.autoReconnect.delay);
+}
 
 function createBot() {
   console.log('🤖 Creating bot...');
   
+  if (reconnectTimeout) {
+    clearTimeout(reconnectTimeout);
+    reconnectTimeout = null;
+  }
+  if (antiAfkInterval) {
+    clearInterval(antiAfkInterval);
+    antiAfkInterval = null;
+  }
+  if (chatInterval) {
+    clearInterval(chatInterval);
+    chatInterval = null;
+  }
+
   const botOptions = {
     host: config.server.host,
     port: config.server.port,
@@ -220,18 +247,12 @@ function createBot() {
 
   bot.on('kicked', (reason) => {
     console.log('⚠️ Bot was kicked:', reason);
-    if (config.features.autoReconnect.enabled) {
-      console.log(`🔄 Reconnecting in ${config.features.autoReconnect.delay / 1000} seconds...`);
-      setTimeout(createBot, config.features.autoReconnect.delay);
-    }
+    scheduleReconnect();
   });
 
   bot.on('end', () => {
     console.log('🔌 Bot disconnected from server');
-    if (config.features.autoReconnect.enabled) {
-      console.log(`🔄 Reconnecting in ${config.features.autoReconnect.delay / 1000} seconds...`);
-      setTimeout(createBot, config.features.autoReconnect.delay);
-    }
+    scheduleReconnect();
   });
 
   bot.on('death', () => {
@@ -354,9 +375,13 @@ function startBotActivities() {
 }
 
 function startAntiAFK() {
+  if (antiAfkInterval) {
+    clearInterval(antiAfkInterval);
+    antiAfkInterval = null;
+  }
   const antiAfkConfig = config.features.antiAFK;
   
-  setInterval(() => {
+  antiAfkInterval = setInterval(() => {
     if (!bot || !bot._client || bot._client.state !== 'play') return;
     
     try {
@@ -392,10 +417,14 @@ function startAntiAFK() {
 }
 
 function startChatMessages() {
+  if (chatInterval) {
+    clearInterval(chatInterval);
+    chatInterval = null;
+  }
   const chatConfig = config.features.chatMessages;
   let messageIndex = 0;
   
-  setInterval(() => {
+  chatInterval = setInterval(() => {
     if (!bot || !bot._client || bot._client.state !== 'play') return;
     
     try {
@@ -439,6 +468,9 @@ createBot();
 // Graceful shutdown
 process.on('SIGINT', () => {
   console.log('🛑 Shutting down bot...');
+  if (reconnectTimeout) clearTimeout(reconnectTimeout);
+  if (antiAfkInterval) clearInterval(antiAfkInterval);
+  if (chatInterval) clearInterval(chatInterval);
   if (bot) {
     bot.quit('Bot shutting down');
   }
@@ -447,6 +479,9 @@ process.on('SIGINT', () => {
 
 process.on('SIGTERM', () => {
   console.log('🛑 Received SIGTERM, shutting down bot...');
+  if (reconnectTimeout) clearTimeout(reconnectTimeout);
+  if (antiAfkInterval) clearInterval(antiAfkInterval);
+  if (chatInterval) clearInterval(chatInterval);
   if (bot) {
     bot.quit('Bot shutting down');
   }
@@ -455,10 +490,7 @@ process.on('SIGTERM', () => {
 
 process.on('uncaughtException', (error) => {
   console.error('💥 Uncaught Exception:', error);
-  if (config.features.autoReconnect.enabled) {
-    console.log('🔄 Restarting bot due to uncaught exception...');
-    setTimeout(createBot, 5000);
-  }
+  scheduleReconnect();
 });
 
 process.on('unhandledRejection', (reason, promise) => {

--- a/package.json
+++ b/package.json
@@ -2,10 +2,10 @@
   "name": "minecraft-afk-bot-fixed",
   "version": "1.0.0",
   "description": "Fixed Minecraft AFK Bot with manual AuthMe support",
-  "main": "bot.js",
+  "main": "bot-authme-first.js",
   "scripts": {
-    "start": "node bot.js",
-    "dev": "node bot.js"
+    "start": "node bot-authme-first.js",
+    "dev": "node bot-authme-first.js"
   },
   "dependencies": {
     "mineflayer": "^4.20.1",


### PR DESCRIPTION
- **Fixed `package.json` entry points:** Updated `main`, `scripts.start`, and `scripts.dev` from `bot.js` to `bot-authme-first.js`. `bot.js` didn't exist in the repository, so running `npm start` failed immediately with a `Cannot find module` error.
- **Fixed server join fallback execution:** `serverJoined` was previously set to `true` immediately when sending the `/server survival` command. Because it was set to `true` right away, the 10-second timeout condition `if (authmeCompleted && !serverJoined)` could never evaluate to true. If a server didn't send a chat message matching the expected join keywords, the fallback would never trigger and the bot would get stuck in the lobby without starting AFK tasks. We now only set `serverJoined = true` once chat confirms the join or when the 10-second fallback timer elapses.
- **Debounced auto-reconnect on kick:** When kicked, Mineflayer emits both `'kicked'` and `'end'` events. Because both handlers scheduled `createBot()` after a delay, every kick spawned two bots connecting simultaneously with the same username, triggering an infinite reconnect/kick loop. Reconnects are now debounced with a single timeout guard (`scheduleReconnect`).
- **Cleaned up intervals on reconnect, respawn, and shutdown:** `startAntiAFK()` and `startChatMessages()` created new `setInterval` timers on every call without clearing existing ones. Over multiple reconnections or deaths, these timers accumulated in the event loop and performed duplicate actions against the bot instance. Interval handles are now stored and cleared properly before creating new loops and on graceful shutdown (`SIGINT`/`SIGTERM`).